### PR TITLE
🎨 style(ProductPage): add full width to main element

### DIFF
--- a/src/components/ProductPage/index.tsx
+++ b/src/components/ProductPage/index.tsx
@@ -14,7 +14,7 @@ const ProductPage: FunctionComponent<ProductPageProps> = ({ product }) => {
     const { id } = product;
 
     return (
-        <main key={id} className="grid min-h-[calc(100dvh-5rem)] lg:grid-cols-2 lg:gap-0">
+        <main key={id} className="grid min-h-[calc(100dvh-5rem)] w-full lg:grid-cols-2 lg:gap-0">
             <ProductsCarousel>
                 <CarouselItems product={product} />
             </ProductsCarousel>

--- a/src/lib/ENProducts.ts
+++ b/src/lib/ENProducts.ts
@@ -191,10 +191,10 @@ export const ShortsProducts: Product[] = [
         sizes: ['Adjustable size'],
         colors: ['Khaki Green'],
         images: [
-            PreviewImageAZHA_STREET,
-            FrontImageAZHA_STREET,
-            BackImageAZHA_STREET,
             SideImageAZHA_STREET,
+            FrontImageAZHA_STREET,
+            PreviewImageAZHA_STREET,
+            BackImageAZHA_STREET,
         ],
     },
 ];

--- a/src/lib/PTProducts.ts
+++ b/src/lib/PTProducts.ts
@@ -191,10 +191,10 @@ export const CalcaoProducts: Product[] = [
         sizes: ['Tamanho ajustável'],
         colors: ['Verde Caqui'],
         images: [
-            PreviewImageAZHA_STREET,
-            FrontImageAZHA_STREET,
-            BackImageAZHA_STREET,
             SideImageAZHA_STREET,
+            FrontImageAZHA_STREET,
+            PreviewImageAZHA_STREET,
+            BackImageAZHA_STREET,
         ],
     },
 ];


### PR DESCRIPTION
🎨 style(ENProducts.ts, PTProducts.ts): reorder images array The main element in the ProductPage component now has a full width, which improves the layout of the page. The images array in both ENProducts.ts and PTProducts.ts files have been reordered to match the order in which the images are displayed on the website. This improves the consistency of the images across the website.